### PR TITLE
Add extra channels to Arduino

### DIFF
--- a/Arduino/I2C_RGB_LED_Controller.ino
+++ b/Arduino/I2C_RGB_LED_Controller.ino
@@ -3,10 +3,13 @@
 #define RED_PIN 9
 #define GREEN_PIN 10
 #define BLUE_PIN 11
+#define WHITE_PIN 3
+#define AUX1_PIN 5
+#define AUX2_PIN 6
 
 #include <Wire.h>
 
-int red, green, blue, pRed, pGreen, pBlue;
+int red, green, blue, pRed, pGreen, pBlue, white, pWhite, aux1, pAux1, aux2, pAux2;
 
 void setup() {
   Serial.begin(9600);
@@ -24,6 +27,15 @@ void loop() {
   if (pBlue != blue) {
     analogWrite(BLUE_PIN, blue);
   }
+  if (pWhite != white) {
+    analogWrite(WHITE_PIN, white);
+  }
+  if (pAux1 != aux1) {
+    analogWrite(AUX1_PIN, aux1);
+  }
+  if (pAux2 != aux2) {
+    analogWrite(AUX2_PIN, aux2);
+  }
   delay(100);
 }
 
@@ -40,6 +52,15 @@ void receiveEvent(int howMany) {
     } else if (num == 2) {
       pBlue = blue;
       blue = val;
+    } else if (num == 3) {
+      pWhite = white;
+      white = val;
+    } else if (num == 4) {
+      pAux1 = aux1;
+      aux1 = val;
+    } else if (num == 5) {
+      pAux2 = aux2;
+      aux2 = val;
     }
     num++;
   }


### PR DESCRIPTION
Modify Arduino code so it can be used with RGBW LED strips

I have also added in two auxiliary channels for future use if needed. One idea is to hook up fairy lights as stars once the sun has set, but this could also be used to support RGBWW strips with warm and cool white LEDs

It is still backwards compatible, if you send only three values, they will be interpreted as R, G, and B. If you send four, then it will be R, G, B, and W. Values do not need to be sent for all channels if they are not  used